### PR TITLE
fix: change application executable name to the upstream one

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -38,10 +38,10 @@ package() {
 	install -dm755 "$pkgdir/usr/share/metainfo"
 
 	# Application executable
-	install -Dm755 "$srcdir/usr/bin/AyuGram" "$pkgdir/usr/bin/ayugram-desktop"
+	install -Dm755 "$srcdir/usr/bin/AyuGram" "$pkgdir/usr/bin/AyuGram"
 
 	# Remove RPATH informations
-	chrpath --delete "$pkgdir/usr/bin/ayugram-desktop"
+	chrpath --delete "$pkgdir/usr/bin/AyuGram"
 
 	# Desktop launcher
 	install -Dm644 "$srcdir/usr/share/icons/hicolor/256x256/apps/com.ayugram.desktop.png" "$pkgdir/usr/share/pixmaps/ayugram.png"


### PR DESCRIPTION
[tdesktop changed binary name from telegram-desktop to Telegram
AyuGram follows the change, the binary name is AyuGram now](https://github.com/AyuGram/AyuGramDesktop/issues/128#issuecomment-3073861747)

PKGBUILD was renaming the binary from AyuGram to ayugram-desktop but it shouldn't do this.

Closes: #11 