### PR TITLE
bump to 7.0.9-5

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ayugram-desktop-bin
 	pkgdesc = Desktop Telegram client with good customization and Ghost mode
 	pkgver = 7.0.9
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/AyuGram/AyuGramDesktop
 	arch = x86_64
 	license = GPL-3.0-or-later
@@ -56,7 +56,7 @@ pkgbase = ayugram-desktop-bin
 	provides = ayugram-desktop
 	conflicts = ayugram-desktop
 	options = !debug
-	source = https://cdn77.cachyos.org/repo/x86_64/cachyos/ayugram-desktop-7.0.9-3-x86_64.pkg.tar.zst
-	sha256sums = 8b0d0c517196327aae7ea7ebf97c4fcb92606ad946da1a05911970d9fa784967
+	source = https://cdn77.cachyos.org/repo/x86_64/cachyos/ayugram-desktop-7.0.9-4-x86_64.pkg.tar.zst
+	sha256sums = a632900ae6a65fe2fde3741bf73dedfb56ae08d011a24f46d227b6db15885738
 
 pkgname = ayugram-desktop-bin

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ayugram-desktop-bin
 	pkgdesc = Desktop Telegram client with good customization and Ghost mode
 	pkgver = 7.0.9
-	pkgrel = 4
+	pkgrel = 5
 	url = https://github.com/AyuGram/AyuGramDesktop
 	arch = x86_64
 	license = GPL-3.0-or-later
@@ -56,7 +56,7 @@ pkgbase = ayugram-desktop-bin
 	provides = ayugram-desktop
 	conflicts = ayugram-desktop
 	options = !debug
-	source = https://cdn77.cachyos.org/repo/x86_64/cachyos/ayugram-desktop-7.0.9-4-x86_64.pkg.tar.zst
-	sha256sums = a632900ae6a65fe2fde3741bf73dedfb56ae08d011a24f46d227b6db15885738
+	source = https://cdn77.cachyos.org/repo/x86_64/cachyos/ayugram-desktop-7.0.9-5-x86_64.pkg.tar.zst
+	sha256sums = b927bd5510e236b18ae67fb59a0b19bf927d203e37239ae0e65ff893a89ef73b
 
 pkgname = ayugram-desktop-bin

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ayugram-desktop-bin
 pkgver=7.0.9
-pkgrel=3
+pkgrel=4
 pkgdesc="Desktop Telegram client with good customization and Ghost mode"
 arch=(x86_64)
 url="https://github.com/AyuGram/AyuGramDesktop"
@@ -29,7 +29,7 @@ conflicts=('ayugram-desktop')
 options=('!debug')
 
 source=("https://cdn77.cachyos.org/repo/${CARCH}/cachyos/ayugram-desktop-${pkgver}-${pkgrel}-${CARCH}.pkg.tar.zst")
-sha256sums=('8b0d0c517196327aae7ea7ebf97c4fcb92606ad946da1a05911970d9fa784967')
+sha256sums=('a632900ae6a65fe2fde3741bf73dedfb56ae08d011a24f46d227b6db15885738')
 
 package() {
     # Binary

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ayugram-desktop-bin
 pkgver=7.0.9
-pkgrel=4
+pkgrel=5
 pkgdesc="Desktop Telegram client with good customization and Ghost mode"
 arch=(x86_64)
 url="https://github.com/AyuGram/AyuGramDesktop"
@@ -29,7 +29,7 @@ conflicts=('ayugram-desktop')
 options=('!debug')
 
 source=("https://cdn77.cachyos.org/repo/${CARCH}/cachyos/ayugram-desktop-${pkgver}-${pkgrel}-${CARCH}.pkg.tar.zst")
-sha256sums=('a632900ae6a65fe2fde3741bf73dedfb56ae08d011a24f46d227b6db15885738')
+sha256sums=('b927bd5510e236b18ae67fb59a0b19bf927d203e37239ae0e65ff893a89ef73b')
 
 package() {
     # Binary


### PR DESCRIPTION
Updates `ayugram-desktop-bin` from `7.0.9-3` to `7.0.9-4`.

Arch Linux has upgraded ada to 4.0.0, while the previous AyuGram binary was linked against libada.so.3.

Updated:

* `pkgrel` from 3 to 4
* SHA256 checksum
* `.SRCINFO`

Tested on Arch Linux with `ada 4.0.0`.
